### PR TITLE
feat(middleware): Allow potential admins to login when backend is locked

### DIFF
--- a/Classes/Middleware/AdminElevationMiddleware.php
+++ b/Classes/Middleware/AdminElevationMiddleware.php
@@ -30,6 +30,7 @@ class AdminElevationMiddleware implements MiddlewareInterface
 	{
 		$backendUser = $this->getBackendUser();
 
+
 		if ($backendUser instanceof BackendUserAuthentication && $backendUser->user) {
 			$this->processAdminElevation($backendUser, $request);
 		}
@@ -43,6 +44,14 @@ class AdminElevationMiddleware implements MiddlewareInterface
 		$this->eventDispatcher->dispatch($event);
 
 		if ($event->shouldSkipProcessing()) {
+			return;
+		}
+
+		if (
+			$GLOBALS['TYPO3_CONF_VARS']['BE']['adminOnly'] > 0 &&
+			$this->canUserElevate($backendUser)
+		) {
+			$this->setAdminElevation($backendUser->user['uid']);
 			return;
 		}
 


### PR DESCRIPTION
When the backend is locked to editors, allow users who _could_ be admins to login and automatically be elevated

Resolves: #1